### PR TITLE
feat: SPT-420 - Add base-path input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
           skip-git-commit: "true"  This is for testing so you don't pollute your git history. Default value is false.
           version-prefix: "v"  useful for repos that terraform modules where the versions are like "v0.2.4".
           settings-file: cicd/settings.json
+          base-path: useful if you need to place the version and changelog files out of root folder. 
       - name: show new version
         run: echo "version released: ${{ steps.semver.outputs.service-version }}"
 ```
@@ -59,10 +60,11 @@ The action will:
 }
 ```
 
-- There are 3 optional parameters in this action:
+- There are 4 optional parameters in this action:
 
 > **skip-commit**: use it with value "true" if you want to prevent the action from committing.
 > **version-prefix**: use with a value different than an empty string ("beta-" or "v" for example) to have tags in the form of '{version-prefix}M.m.p'
+> **base-path**: use it if you want to place version and changelog files out of root folder.
 > **settings-file**: path to a JSON file where you can define your custom conventional commits and scopes. Next is an example:
 
 ```json

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   settings-file:
     description: "json files with the custom conventional commit type vs release type associated. DO NOT PROVIDE WITH ./ AT THE BEGINING"
     required: false
+  base-path:
+    description: "path where it will be located version and changelog files. DO NOT PROVIDE WITH ./ AT THE BEGINING"
+    required: false
 
 outputs:
   service-version:
@@ -33,6 +36,7 @@ runs:
         SKIP_GIT_COMMIT: ${{ inputs.skip-git-commit }} 
         VERSION_PREFIX: ${{ inputs.version-prefix }}
         SETTINGS_FILE: ${{ inputs.settings-file }}
+        BASE_PATH: ${{ inputs.base-path }}
       run: |
         git config user.email ${{ inputs.user-email }}
         git config user.name ${{ inputs.user-name }}
@@ -40,5 +44,5 @@ runs:
       shell: bash
     - id: service-version
       run: |
-        echo "::set-output name=service-version::$(cat ./version.json | jq -r '.version')"
+        echo "::set-output name=service-version::$(cat ./${{ inputs.base-path }}/version.json | jq -r '.version')"
       shell: bash


### PR DESCRIPTION
We are working on allowing to have auto versioned libraries on a repo (for example a library repo). 
In order to have a version out of root folder we added the base-path input parameter to indicate where need to be placed the action artifacts.

- Execution [sample whiteout base-path parameter](https://github.com/ohpen/shared-oauth-lib-dotnet/runs/7782044170?check_suite_focus=true)
![image](https://user-images.githubusercontent.com/94201128/184083596-1a5e5e5e-2967-4b12-8f8e-10e5354e95a5.png)
From [version-and-release job on shared-oauht-lib-dotnet workflow line 91](https://github.com/ohpen/shared-oauth-lib-dotnet/blob/feature/SPT-420/.github/workflows/push-to-main.yml)
![image](https://user-images.githubusercontent.com/94201128/184084149-fd80970f-3741-4968-aede-1292520cd528.png)[commit generated 3ffc0138a3d2d7ad9974152bf1ba17dbce8e94fb](https://github.com/ohpen/shared-oauth-lib-dotnet/commit/3ffc0138a3d2d7ad9974152bf1ba17dbce8e94fb)

- Execution [sample with base-path parameter](https://github.com/ohpen/shared-oauth-lib-dotnet/runs/7782023647?check_suite_focus=true)
![image](https://user-images.githubusercontent.com/94201128/184084662-0e9b1c58-e8ad-4225-b191-12ab1c1bf289.png)
From version-pack-and-push-package action on package-version-and-release-notes step line 46
![image](https://user-images.githubusercontent.com/94201128/184085291-d58d4946-3b47-4c63-a185-6f26bac2e530.png)
[commit generated 091da15f73078ac4376af43b3ffa7dc951cbfe34](https://github.com/ohpen/shared-oauth-lib-dotnet/commit/091da15f73078ac4376af43b3ffa7dc951cbfe34)




