### PR TITLE
feat: SPT-440 - Add scopesDiscovery parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ The action will:
             "folderPattern": "app3",
             "versioning": true
         }
-    }
+    },
+    "scopesDiscovery": true
 }
 ```
 
@@ -116,6 +117,7 @@ The action will:
   * Every scope MUST have a `folderPattern` where a specific CHANGELOG.md will be updated with the commits that contain that scope.
   * If a commit does not provide a scope it will be listed in the root changelog.
   * Optionally, `versioning` per scope is supported by setting `versioning: true` in the scope properties, if not provided, the default value is _false_. It works as next: If a commit with the scope is merged, the new version will be calculated and stored in a  _version.json_ file located in the `folderPattern` directory. Commits will be analyzed following `conventionalCommits` settings.
+* Scopes discovery (key: `scopesDiscovery`): Specify if scopes will be discovered although are not present on commit message. The default value is false.
 
 If no `conventionalCommits` are defined in the `settings-file`, the commit types (prefixes) accepted would be:
 

--- a/main.js
+++ b/main.js
@@ -17,9 +17,9 @@ const settings = settingsProvider.getSettings(process.env.SETTINGS_FILE)
 logger.logKeyValuePair('settings', settings)
 const commitsMerged = git.getChangesFromLastCommit() // changes MUST be squashed into the last commit
 
-let commitsParsed = commitsMerged
+let commitsParsed = commitsMerged.changes
     .map(commit =>
-        commitParser.parseCommitMessage(commit, settings.conventionalCommits))
+        commitParser.parseCommitMessage(commit, commitsMerged.shortHash, settings))
 
 commitsParsed.forEach((commit, index) => logger.logKeyValuePair(`commit ${index}`, commit));
 

--- a/modules/commit-parser.js
+++ b/modules/commit-parser.js
@@ -1,6 +1,9 @@
+const git = require('./git.js')
 const REGEX_CONVENTIONAL_COMMIT_FORMAT = /(?<type>^[a-z\d]+)\(?(?<scopes>[a-z\d,\-]+)?\)?(?<breaking>!)?(?<colon>:{1})(?<space> {1})(?<body>.*)/
 
-const parseCommitMessage = (commitMsg, types) => {
+const parseCommitMessage = (commitMsg, commitHash, settings) => {
+
+  const types = settings.conventionalCommits
 
   let result = {
     body: commitMsg,
@@ -18,7 +21,7 @@ const parseCommitMessage = (commitMsg, types) => {
 
   let { type, scopes, body, breaking } = matchResult.groups
 
-  const scopesArray = scopes ? scopes.split(",") : []
+  const scopesArray = getScopes(scopes, commitHash, settings)
 
   result.body = body
   result.type = type || ""
@@ -26,6 +29,38 @@ const parseCommitMessage = (commitMsg, types) => {
   result.scopes = scopesArray
 
   return result
+}
+
+const getScopes = (commitScopes, commitHash, settings) => {
+  const scopesDiscovery = settings.scopesDiscovery
+  const commitScopesArray =  commitScopes ? commitScopes.split(",") : []
+
+  if (!scopesDiscovery) {   
+    return commitScopesArray
+  }
+  
+  const settingsScopes = settings.scopes
+  const autodiscoveredScopesArray = getAutodiscoveredScopes(commitHash, settingsScopes)
+
+  const result = commitScopesArray.concat(autodiscoveredScopesArray)
+  
+  return [...new Set(result)] 
+}
+
+const getAutodiscoveredScopes = (commitHash, configScopes) => {  
+  let filesModified = git.getFilesModifiedInACommit(commitHash)
+
+  let result = []
+    const folderPatterns = Object.entries(configScopes).map(x => x[1].folderPattern)
+    filesModified.forEach(file => {
+      const fileHasScopeAssociated = folderPatterns.some(x => file.includes(x))
+      if (fileHasScopeAssociated) {
+          const missingScope = Object.entries(configScopes).find(x => file.includes(x[1].folderPattern))[0]
+          result.push(missingScope)
+      }
+    })
+
+    return [...new Set(result)]
 }
 
 module.exports = {

--- a/modules/git.js
+++ b/modules/git.js
@@ -40,10 +40,13 @@ const getChangesFromLastCommit = () => {
     .map((block) => block.replace("* ", ""));
 
   if (changes.length === 0) {
-    changes = [lastCommit.subject]
+    changes = new Array(lastCommit.subject)
   }
 
-  return changes;
+  return {
+    shortHash: lastCommit.shortHash,
+    changes: changes
+  };
 };
 
 const getCommitInfo = (commitToParse) => {
@@ -77,6 +80,12 @@ const getCommitInfo = (commitToParse) => {
 };
 
 
+const getFilesModifiedInACommit = (commitHash) => child
+.execSync(`git diff-tree --no-commit-id --name-only -r ${commitHash}`)
+.toString("utf-8")
+.split("\n")
+.filter(line => line.length > 0)
+
 function commitAndTag(commitMsg, tagMsg, tag) {
   child.execSync(`git commit -m "${commitMsg}"`)
   child.execSync(`git tag -a -m "${tagMsg}" ${tag}`)
@@ -90,5 +99,6 @@ function addFile(file) {
 module.exports = {
   getChangesFromLastCommit,
   commitAndTag,
-  addFile
+  addFile,
+  getFilesModifiedInACommit
 };

--- a/modules/settings-provider.js
+++ b/modules/settings-provider.js
@@ -41,7 +41,8 @@ getSettings = (settingsFile) => {
 
     let result = {
         conventionalCommits: DEFAULT_CONVENTIONAL_COMMITS,
-        scopes: {}
+        scopes: {},
+        scopesDiscovery: false
     }
 
     if (settingsFile && !fs.existsSync(settingsFile)) {
@@ -52,6 +53,7 @@ getSettings = (settingsFile) => {
         const jsonData = fileTools.getJsonFrom(settingsFile)
         result.conventionalCommits = jsonData?.conventionalCommits ?? DEFAULT_CONVENTIONAL_COMMITS
         result.scopes = jsonData?.scopes ?? {}
+        result.scopesDiscovery = jsonData?.scopesDiscovery ?? false
     }
 
     return result


### PR DESCRIPTION
## Description

This feature is aiming the possibility to know witch scopes are affected per commit, although the commit message does not have an scope on its message. This it will be useful on automated commits generated by Sync.

In order to achieve that goal we add a 'scopesDiscovery' parameter on settings file.

'scopesDiscovery': Specify if scopes will be discovered although are not present on commit message. The default value is false.

## Executions Tests
### scopesDiscovery: true - commit with scopes changes - commit message without scopes
[action link sample](https://github.com/ohpen/shared-oauth-lib-dotnet/actions/runs/3141301305/jobs/5103588868)

settings file details
![image](https://user-images.githubusercontent.com/94201128/192457638-5285e375-21eb-4103-8fa2-22af9067f150.png)

The [commit](https://github.com/ohpen/shared-oauth-lib-dotnet/commit/f350f1820d079a3f160710318ceb321234854f2f) change files on scopes: ohpen-oauth-abstractions, ohpen-oauth, and has not scopes on its message.

The action with scopesDiscovery = true it's able to discover the scopes affected for that commit
![image](https://user-images.githubusercontent.com/94201128/192705129-39ff56e7-ce87-4719-aeec-802374817f45.png)

### scopesDiscovery: false - commit with scopes changes - commit message without scopes
[action link sample](https://github.com/ohpen/shared-oauth-lib-dotnet/actions/runs/3141244106/jobs/5103468286)

settings file details
![image](https://user-images.githubusercontent.com/94201128/192460802-f0cb54eb-b1dd-4d43-9273-0a531d2b7a3f.png)

The [commit](https://github.com/ohpen/shared-oauth-lib-dotnet/commit/46347d7e670316e82246cf03c34fca41cf7eecb0) change files on scopes: ohpen-oauth-abstractions, ohpen-oauth, and has not scopes on its message.

The action with scopesDiscovery = false it's not able to discover the scopes affected for that commit
![image](https://user-images.githubusercontent.com/94201128/192703755-30ea9323-60f5-4609-b8f0-1a136f18a145.png)
